### PR TITLE
Chiara/fix wifi encryption bug

### DIFF
--- a/src/RouterSettings/Wifi.js
+++ b/src/RouterSettings/Wifi.js
@@ -38,9 +38,8 @@ const Wifi = () => {
 
       wifiSettings.map(setting => {
         let radio = setting.device.sectionName;
-        let { ssid, key } = setting;
+        let { ssid, key, encryption } = setting;
         let channel = parseInt(setting.device.channel, 10);
-        let encryption = setting.device.encryption;
 
         //convert from string to boolean: '0' === enabled = false, '1' === disabled = true
         let disabled = setting.device.disabled === "1";


### PR DESCRIPTION
Encryption field should have been read from wifiSettings
instead of from the device field within it, causing an
error when trying to save wifi config