### PR TITLE
Handle KeyLTE check when version null

### DIFF
--- a/src/RouterSettings/PortColumns.js
+++ b/src/RouterSettings/PortColumns.js
@@ -28,6 +28,9 @@ const PortColumns = ({
   const [{ version }] = useStore();
   function checkIfKeyLTE() {
     // if this is a KeyLTE router the LTE port assignment is disabled.
+    if (version == null) {
+      return false;
+    }
     let version_string = version.toLowerCase();
     if (version_string.includes("keylte")) {
       return true;


### PR DESCRIPTION
When toggling ports, version becomes none which causes this KeyLTE function to break the DOM tree. We handle this case and return false when we see no version. It shouldnt matter since the ports are disabled during this time